### PR TITLE
Fix warning on project start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,16 @@
   "displayName": "Custom Script Template",
   "description": "This tool adds another Script Template to Unity that will serve as an alternative for the default \"C#Script\" that I personally always modify before writing my scripts. In essence, it adds a signature header on every script with your name, email and creation date. Also, it removes the Start() and Update() methods from the default template.",
   "unity": "2018.3",
-  "keywords": [ "custom", "script", "template", "tool", "extension", "editor" ],
+  "keywords": [
+    "custom",
+    "script",
+    "template",
+    "tool",
+    "extension",
+    "editor"
+  ],
   "author": {
-    "name": "Jo„o Borks",
+    "name": "Jo√£o Borks",
     "email": "joao.borks@gmail.com",
     "url": "https://github.com/JoaoBorks"
   }


### PR DESCRIPTION
At first project start or when you just imported the package, this warning showed up:
```
Invalid AssetDatabase path: D:/Projects/Prothos/osp-app/Library/PackageCache\com.joaoborks.customscripttemplate@8b6929d08e\CustomScriptTemplate\Source\81-C# Custom Script-NewBehaviourScript.cs.txt. Use path relative to the project folder.
UnityEditor.AssetDatabase:LoadAssetAtPath(String)
CustomScriptTemplate.CustomScriptTemplateEditor:get_ScriptTemplate() (at Library/PackageCache/com.joaoborks.customscripttemplate@8b6929d08e/CustomScriptTemplate/Editor/CustomScriptTemplateEditor.cs:47)
CustomScriptTemplate.CustomScriptTemplateEditor:OnGUI() (at Library/PackageCache/com.joaoborks.customscripttemplate@8b6929d08e/CustomScriptTemplate/Editor/CustomScriptTemplateEditor.cs:244)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr)
```

It was caused due to an access to `isPackage` before its value were set.